### PR TITLE
Fix vscode-elixir compaitibllity

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   ],
   "activationEvents": [
     "onLanguage:eex",
-    "onLanguage:HTML (EEx)"
+    "onLanguage:HTML (EEx)",
+    "onLanguage:HTML (Eex)"
   ],
   "main": "./out/extension",
   "contributes": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,7 +8,7 @@ import * as cp from "child_process";
 // your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
   vscode.languages.registerDocumentFormattingEditProvider(
-    ["eex", "HTML (EEx)"],
+    ["eex", "HTML (EEx)", "HTML (Eex)"],
     {
       provideDocumentFormattingEdits(
         document: vscode.TextDocument


### PR DESCRIPTION
Make sure that the plugin is compatible with vscode-elixir since the name of the file format is case sensitive.

Fix for #1 