### PR TITLE
Call htmlbeautifier's help option, instead of version.

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,7 +14,7 @@ export function activate(context: vscode.ExtensionContext) {
         document: vscode.TextDocument
       ): vscode.TextEdit[] {
         const ext = process.platform === "win32" ? ".bat" : "";
-        const beautifier = cp.spawn(`htmlbeautifier${ext}`, ["-v"]);
+        const beautifier = cp.spawn(`htmlbeautifier${ext}`, ["help"]);
 
         beautifier.on("error", err => {
           if (err.message.includes("ENOENT")) {
@@ -57,12 +57,12 @@ export function activate(context: vscode.ExtensionContext) {
 }
 
 // this method is called when your extension is deactivated
-export function deactivate() {}
+export function deactivate() { }
 
 function cli_options() {
   const config = vscode.workspace.getConfiguration("vscode-eex-beautify");
   let acc: string[] = [];
-  return Object.keys(config).reduce(function(acc, key) {
+  return Object.keys(config).reduce(function (acc, key) {
     switch (key) {
       case "indentBy":
         acc.push("--indent-by", config[key]);


### PR DESCRIPTION
Using the latest version of `htmlbeautifier` (0.13.1), as of the time of this writing, the extension displays this error message: **couldn't find htmlbeautifier for formatting (ENOENT)**. I realized that the extension calling `htmlbeautifier -v` caused the error. So instead, I modified the code to make the extension call `htmlbeautifier --help` instead. This fixes the problem.